### PR TITLE
ci: Add Pull Request Title Check

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,27 @@
+name: "Pull Request Checks"
+
+on:
+  pull_request:
+    types:
+      [
+        opened,
+        edited,
+        unlocked,
+        labeled,
+        synchronize,
+        reopened,
+        ready_for_review,
+      ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check-pr-title:
+    name: Check PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR Title
+        uses: deepakputhraya/action-pr-title@v1.0.2
+        with:
+          allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: " # title should start with the given prefix


### PR DESCRIPTION
# Description

This change introduces a new GitHub Actions workflow for pull request checks. The workflow, named "Pull Request Checks," is triggered on various pull request events such as opening, editing, synchronising, and reopening.

This addition will help maintain consistency in pull request titles and  allows release please to generate releases.

fixes #18

