### PR TITLE
ci: Check Markdown Links

### DIFF
--- a/.github/other-configurations/.linkspector.yml
+++ b/.github/other-configurations/.linkspector.yml
@@ -1,0 +1,7 @@
+dirs:
+  - ./
+  - ./docs
+excludedFiles:
+  - ./CHANGELOG.md
+aliveStatusCodes:
+  - 200

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -42,3 +42,21 @@ jobs:
           VALIDATE_TYPESCRIPT_STANDARD: false
           VALIDATE_TSX: false
           VALIDATE_TSX_PRETTIER: false
+
+  check-markdown-links:
+    name: Check Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check Markdown links
+        uses: UmbrellaDocs/action-linkspector@v1.2.1
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          config_file: .github/other-configurations/.linkspector.yml
+          reporter: github-pr-review
+          fail_on_error: true
+          filter_mode: nofilter


### PR DESCRIPTION
# Description

This change introduces a new workflow step to check Markdown links in the repository. A new configuration file `.linkspector.yml` is added to specify the directories to scan, files to exclude, and acceptable status codes for link validation.

The `code-quality.yml` workflow file is updated to include a new job called "Check Markdown links". This job uses the UmbrellaDocs/action-linkspector action to validate links in Markdown files. The action is configured to use the newly added `.linkspector.yml` file, report results as GitHub PR reviews, fail on errors, and run without filtering.

This enhancement will help maintain the quality of documentation by ensuring that all links in Markdown files are valid and accessible.

fixes #25