### PR TITLE
chore: Force Minor Release

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -40,5 +40,6 @@
       "release-type": "simple"
     }
   },
-  "draft-pull-request": true
+  "draft-pull-request": true,
+  "versioning": "always-bump-minor"
 }


### PR DESCRIPTION
# Description

This change modifies the release-please configuration to always bump the minor version. The `versioning` property is set to `"always-bump-minor"` in the `.github/release-please/release-please-config.json` file. 

fixes #51