### PR TITLE
chore: Fix Prettier Warning for Release

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -41,5 +41,5 @@
     }
   },
   "draft-pull-request": true,
-  "versioning": "always-bump-minor"
+  "bump-minor-pre-major": true
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
# Description

This change modifies the release-please configuration and adds a new Prettier ignore file. 

In the release-please config, the "versioning" strategy has been updated from "always-bump-minor" to "bump-minor-pre-major". This change affects how version numbers are incremented for pre-major releases.

A new `.prettierignore` file has been added to exclude the `CHANGELOG.md` file from Prettier formatting. 

fixes #53