### PR TITLE
ci: Add Docker Dependency Updates to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "main"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    commit-message:
+      prefix: "deps(docker)"
+    schedule:
+      interval: "monthly"
+    target-branch: "main"


### PR DESCRIPTION
# Description

This change adds Docker dependency management to the existing Dependabot configuration. The new configuration checks for Docker updates monthly, targeting the main branch. Commit messages for Docker-related updates will be prefixed with "deps(docker)".

fixes #56