### PR TITLE
build: Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.github
+.vscode
+docs
+githooks
+test


### PR DESCRIPTION
# Description

Added a `.dockerignore` file to exclude specific directories and files from the Docker build context. This change improves build performance and reduces the size of the Docker image by preventing unnecessary files from being copied into the container. The following items are now ignored:

- `.github` directory
- `.vscode` directory
- `docs` directory
- `githooks` directory
- `test` directory

This optimisation ensures that only essential files are included in the Docker image, resulting in faster builds and smaller image sizes.

fixes #73