### PR TITLE
ci: Override coverage source path for SonarCloud

### DIFF
--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run Unit Tests
         run: just unit-test
 
+      - name: Override Coverage Source Path for SonarCloud
+        run: sed -i "s/<source>\/home\/runner\/work\/project-status-checker\/project-status-checker<\/source>/<source>\/github\/workspace<\/source>/g" /home/runner/work/project-status-checker/project-status-checker/coverage.xml
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v3.1.0
         env:


### PR DESCRIPTION
# Description

This change adds a new step to the code-test.yml workflow file to override the coverage source path for SonarCloud. The new step uses `sed` to replace the source path in the coverage.xml file, changing it from `/home/runner/work/project-status-checker/project-status-checker` to `/github/workspace`. This modification ensures that SonarCloud can correctly locate and analyse the source files during the scan process.

fixes #76