### PR TITLE
ci: Update coverage path in unit test command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -20,7 +20,7 @@ install:
     poetry install
 
 unit-test:
-    poetry run pytest checker --cov=checker --cov-report=xml
+    poetry run pytest checker --cov=. --cov-report=xml
 
 # Build the Docker image
 docker-build:


### PR DESCRIPTION
# Description

This change modifies the unit test command in the Justfile to expand the coverage scope. Instead of limiting coverage to the `checker` directory, it now covers the entire project root (`.`). This adjustment ensures that the test coverage report includes all relevant code within the project, providing a more comprehensive overview of the test coverage.

fixes #78