### PR TITLE
ci: Add size labels to pull request labelling workflow

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -26,11 +26,17 @@ jobs:
         with:
           allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: " # title should start with the given prefix
   labeller:
-    name: Labeller
+    name: Label Pull Request
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - name: Label Pull Request
+        uses: actions/labeler@v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/other-configurations/labeller.yml
           sync-labels: true
+
+      - name: Add Size Labels
+        uses: pascalgn/size-label-action@v0.5.5
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Description

This pull request enhances the pull request labelling process in the GitHub Actions workflow. It updates the existing labeler action to version 5.0.0 and adds a new step to automatically apply size labels to pull requests. The workflow now includes:

1. An updated "Label Pull Request" step using `actions/labeler@v5.0.0`.
2. A new "Add Size Labels" step using `pascalgn/size-label-action@v0.5.5`.

These changes will improve the categorisation and management of pull requests by automatically applying relevant labels based on the PR content and size.

fixes #87