### PR TITLE
ci: Configure size labels for pull request checks

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -40,3 +40,13 @@ jobs:
         uses: pascalgn/size-label-action@v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          with:
+          sizes: >
+            {
+              "0": "XS",
+              "20": "S",
+              "50": "M",
+              "200": "L",
+              "500": "XL",
+              "1000": "XXL"
+            }


### PR DESCRIPTION
# Description

This change updates the size-label-action configuration in the pull-request-checks.yml workflow. It adds custom size thresholds for labeling pull requests based on the number of lines changed. The new configuration defines six size categories: XS (0-19 lines), S (20-49 lines), M (50-199 lines), L (200-499 lines), XL (500-999 lines), and XXL (1000+ lines). This enhancement provides more granular and meaningful size labels for pull requests, helping reviewers quickly assess the scope of changes.

fixes #95