### PR TITLE
ci: Adjust size thresholds for pull request labels

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -40,13 +40,13 @@ jobs:
         uses: pascalgn/size-label-action@v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          with:
+        with:
           sizes: >
             {
               "0": "XS",
-              "20": "S",
-              "50": "M",
+              "40": "S",
+              "100": "M",
               "200": "L",
-              "500": "XL",
-              "1000": "XXL"
+              "800": "XL",
+              "2000": "XXL"
             }


### PR DESCRIPTION
# Pull Request

## Description

This change updates the size thresholds for the pull request size labelling action. The modifications adjust the boundaries for each size category:

- Small (S) now applies to changes between 40 and 99 lines (previously 20-49)
- Medium (M) now applies to changes between 100 and 199 lines (previously 50-199)
- Large (L) remains unchanged, applying to changes between 200 and 799 lines
- Extra Large (XL) now applies to changes between 800 and 1999 lines (previously 500-999)
- Extra Extra Large (XXL) now applies to changes of 2000 lines or more (previously 1000+)

These adjustments aim to provide a more accurate representation of pull request sizes, allowing for better categorisation and management of code changes.

fixes #100