### PR TITLE
ci: Upload Ruff SARIF to GitHub

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -1,0 +1,39 @@
+name: "Code Scanning"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  packages: read
+  statuses: write
+  security-events: write
+
+jobs:
+  upload-python-scanner-results:
+    name: Upload Python Ruff Scanner Results
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python Dependencies
+        uses: ./.github/actions/setup-dependencies
+
+      - name: Check Python Code Quality (Ruff)
+        run: just ruff-lint
+        env:
+          RUFF_OUTPUT_FORMAT: "sarif"
+          RUFF_OUTPUT_FILE: "ruff-results.sarif"
+        continue-on-error: true
+
+      - name: Upload analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3.27.0
+        with:
+          sarif_file: ruff-results.sarif
+          wait-for-processing: true


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Actions workflow for code scanning, specifically targeting Python code quality checks using Ruff. The most important changes include the addition of the workflow configuration and the steps to set up dependencies, run the Ruff linter, and upload the analysis results.

New GitHub Actions Workflow:

* Added a new workflow named "Code Scanning" triggered on pushes to the `main` branch and pull request events. (`.github/workflows/code-scanning.yml`)
* Configured job permissions to read contents and packages, and write statuses and security events. (`.github/workflows/code-scanning.yml`)
* Defined a job named `upload-python-scanner-results` to run on `ubuntu-latest`. (`.github/workflows/code-scanning.yml`)
* Included steps to checkout the repository, set up Python dependencies, run the Ruff linter, and upload the SARIF results to GitHub. (`.github/workflows/code-scanning.yml`)

fixes #107 