### PR TITLE
chore: Update GitHub Actions Dependabot Groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,13 @@ updates:
       time: "01:00"
       timezone: "Europe/London"
     target-branch: "main"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `.github/dependabot.yml` file to add a new group for GitHub Actions updates. The change introduces a grouping mechanism to better manage dependency updates.

Dependency management improvements:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R14-R20): Added a `groups` section for `github-actions` with patterns and update types to manage patch and minor updates more effectively.

Fixes #147 