### PR TITLE
chore: Ungroup Major Application Dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,13 @@ updates:
       time: "01:00"
       timezone: "Europe/London"
     target-branch: "main"
+    groups:
+      docker:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -44,3 +51,6 @@ updates:
       python:
         patterns:
           - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the `.github/dependabot.yml` file to configure dependency update groups and specify update types for different ecosystems.

Dependency update configuration:

* Added a `docker` group with patterns and update types for `patch` and `minor` updates.
* Specified update types for the `python` ecosystem to include `patch` and `minor` updates.

Fixes #156 