### PR TITLE
ci: Split Code Limit into separate job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -146,6 +146,14 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.27.0
 
+  run-code-limit:
+    name: Run Code Limit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0g
       - name: "Run Code Limit"
         uses: getcodelimit/codelimit-action@8ee70f8d3d5b984130e46fb8ccbe229f5e1d68d0
         with:

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
-          fetch-depth: 0g
+          fetch-depth: 0
       - name: "Run Code Limit"
         uses: getcodelimit/codelimit-action@8ee70f8d3d5b984130e46fb8ccbe229f5e1d68d0
         with:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes the addition of a new job in the GitHub Actions workflow file to run a code limit check. The most important change involves setting up a new job to ensure code size limits are enforced.

Additions to GitHub Actions workflow:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R149-R156): Added a new job named `run-code-limit` to the workflow, which includes steps for checking out the repository and running the code limit action.

Fixes #161 
