### PR TITLE
refactor: Update Just Commands

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -58,19 +58,19 @@ ruff-fix:
 
 # Check for Ruff issues
 ruff-lint:
-    poetry run ruff check checker
+    poetry run ruff check .
 
 # Fix Ruff lint issues
 ruff-lint-fix:
-    poetry run ruff check checker --fix
+    poetry run ruff check . --fix
 
 # Check for Ruff format issues
 ruff-format:
-    poetry run ruff format --check checker
+    poetry run ruff format --check .
 
 # Fix Ruff format issues
 ruff-format-fix:
-    poetry run ruff format checker
+    poetry run ruff format .
 
 # ------------------------------------------------------------------------------
 # Prettier

--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,26 @@
 # ------------------------------------------------------------------------------
-# General Commands
+# Common Commands
 # ------------------------------------------------------------------------------
 
+install:
+    poetry install
+
+# Run the checker
+run:
+    poetry run python -m checker
+
+# ------------------------------------------------------------------------------
+# Test Commands
+# ------------------------------------------------------------------------------
+
+unit-test:
+    poetry run pytest checker --cov=. --cov-report=xml
+
+# ------------------------------------------------------------------------------
+# Cleaning Commands
+# ------------------------------------------------------------------------------
+
+# Clean up all cache and temporary files
 clean:
     find . \( \
       -name '__pycache__' -o \
@@ -16,15 +35,9 @@ clean:
       -name 'db.sqlite3' \
     \) -print | xargs rm -rfv
 
-install:
-    poetry install
-
-# Run the checker
-run:
-    poetry run python -m checker
-
-unit-test:
-    poetry run pytest checker --cov=. --cov-report=xml
+# ------------------------------------------------------------------------------
+# Docker Commands
+# ------------------------------------------------------------------------------
 
 # Build the Docker image
 docker-build:
@@ -34,24 +47,30 @@ docker-run:
     docker run --rm jackplowman/project-status-checker:latest
 
 # ------------------------------------------------------------------------------
-# Ruff - # Set up red-knot when it's ready
+# Ruff - Python Linting and Formatting
+# Set up ruff red-knot when it's ready
 # ------------------------------------------------------------------------------
 
+# Fix all Ruff issues
 ruff-fix:
     just ruff-format-fix
     just ruff-lint-fix
 
+# Check for Ruff issues
 ruff-lint:
-    poetry run ruff check .
+    poetry run ruff check checker
 
+# Fix Ruff lint issues
 ruff-lint-fix:
-    poetry run ruff check . --fix
+    poetry run ruff check checker --fix
 
+# Check for Ruff format issues
 ruff-format:
-    poetry run ruff format --check .
+    poetry run ruff format --check checker
 
+# Fix Ruff format issues
 ruff-format-fix:
-    poetry run ruff format .
+    poetry run ruff format checker
 
 # ------------------------------------------------------------------------------
 # Prettier


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes significant updates to the `Justfile`, focusing on adding new commands and reorganizing existing ones. The changes aim to enhance the usability and organization of the commands within the file.

New commands added:

* `install`: Added a command to install dependencies using `poetry`. (F5695808L6)
* `run`: Added a command to run the checker using `poetry`. (F5695808L9)
* `unit-test`: Added a command to run unit tests with coverage reporting using `pytest` and `poetry`. (F5695808L15)

Reorganization and cleanup:

* Moved the `install`, `run`, and `unit-test` commands to a new section labeled "Common Commands". (F5695808L1)
* Added new sections for "Test Commands", "Cleaning Commands", and "Docker Commands" to better organize the file. (F5695808L12, F5695808L22, F5695808L28)
* Updated Ruff commands to include descriptions and added commands for fixing and checking Ruff lint and format issues. (F5695808L39)
