### PR TITLE
build: Save Results into Database

### DIFF
--- a/checker/save_results.py
+++ b/checker/save_results.py
@@ -1,4 +1,5 @@
-from sqlite3 import Cursor, connect
+from datetime import datetime, UTC
+from sqlite3 import Connection, Cursor, connect
 
 from structlog import get_logger, stdlib
 
@@ -8,7 +9,7 @@ from checker.url_check_result import URLCheckResult
 logger: stdlib.BoundLogger = get_logger()
 
 
-def save_results(application_configuration: ApplicationConfiguration, _results: list[URLCheckResult]) -> None:
+def save_results(application_configuration: ApplicationConfiguration, results: list[URLCheckResult]) -> None:
     """Save the results to a database.
 
     Args:
@@ -17,14 +18,41 @@ def save_results(application_configuration: ApplicationConfiguration, _results: 
     """
     with connect(application_configuration.output_file_path) as connection:
         cursor = connection.cursor()
-        create_tables_if_not_exist(cursor)
-        connection.commit()
+        create_tables_if_not_exist(connection,cursor)
+        for result in results:
+            update_results_table(result, connection, cursor)
 
 
-def create_tables_if_not_exist(cursor: Cursor) -> None:
+def update_results_table(result: URLCheckResult, connection:Connection, cursor:Cursor) -> None:
+    """Update the results table with the URL check result.
+
+    Args:
+        result (URLCheckResult): The URL check result.
+        connection (Connection): The database connection.
+        cursor (Cursor): The database cursor.
+    """
+    # Check if the URL is already in the database
+    cursor.execute("SELECT url_id FROM url WHERE url = ?", (result.url.address,))
+    url_id = cursor.fetchone()
+    # If the URL is not in the database, add it
+    if url_id is None:
+        cursor.execute("INSERT INTO url (alias, url) VALUES (?, ?)", (result.url.address, result.url.address))
+        cursor.execute("SELECT url_id FROM url WHERE url = ?", (result.url.address,))
+        url_id = cursor.fetchone()
+    # Add the result to the results table
+    cursor.execute(
+        "INSERT INTO results (url_id, success, date_time_stamp) VALUES (?, ?, ?)",
+        (url_id[0], result.success, datetime.now(UTC)),
+    )
+    # Commit the changes
+    connection.commit()
+
+
+def create_tables_if_not_exist(connection:Connection, cursor: Cursor) -> None:
     """Create the tables if they do not exist.
 
     Args:
+        connection (Connection): The database connection.
         cursor (Cursor): The database cursor.
     """
     tables_created = []
@@ -51,3 +79,4 @@ def create_tables_if_not_exist(cursor: Cursor) -> None:
         tables_created.append("results")
     if tables_created:
         logger.info("Tables created", tables=tables_created)
+        connection.commit()

--- a/checker/save_results.py
+++ b/checker/save_results.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 from sqlite3 import Connection, Cursor, connect
 
 from structlog import get_logger, stdlib
@@ -18,12 +18,12 @@ def save_results(application_configuration: ApplicationConfiguration, results: l
     """
     with connect(application_configuration.output_file_path) as connection:
         cursor = connection.cursor()
-        create_tables_if_not_exist(connection,cursor)
+        create_tables_if_not_exist(connection, cursor)
         for result in results:
             update_results_table(result, connection, cursor)
 
 
-def update_results_table(result: URLCheckResult, connection:Connection, cursor:Cursor) -> None:
+def update_results_table(result: URLCheckResult, connection: Connection, cursor: Cursor) -> None:
     """Update the results table with the URL check result.
 
     Args:
@@ -48,7 +48,7 @@ def update_results_table(result: URLCheckResult, connection:Connection, cursor:C
     connection.commit()
 
 
-def create_tables_if_not_exist(connection:Connection, cursor: Cursor) -> None:
+def create_tables_if_not_exist(connection: Connection, cursor: Cursor) -> None:
     """Create the tables if they do not exist.
 
     Args:

--- a/checker/tests/test_save_results.py
+++ b/checker/tests/test_save_results.py
@@ -40,7 +40,7 @@ def test_create_tables_if_not_exist() -> None:
     # Simulate no tables existing
     mock_cursor.fetchone.side_effect = [None, None]
     # Act
-    create_tables_if_not_exist(mock_connection,mock_cursor)
+    create_tables_if_not_exist(mock_connection, mock_cursor)
     # Assert
     mock_cursor.execute.assert_any_call("SELECT name FROM sqlite_master WHERE type='table' AND name='url'")
     mock_cursor.execute.assert_any_call(
@@ -74,7 +74,9 @@ def test_update_results_table(mock_datetime: MagicMock) -> None:
     update_results_table(mock_result, mock_connection, mock_cursor)
     # Assert
     mock_cursor.execute.assert_any_call("SELECT url_id FROM url WHERE url = ?", ("http://example.com",))
-    mock_cursor.execute.assert_any_call("INSERT INTO url (alias, url) VALUES (?, ?)", ("http://example.com", "http://example.com"))
+    mock_cursor.execute.assert_any_call(
+        "INSERT INTO url (alias, url) VALUES (?, ?)", ("http://example.com", "http://example.com")
+    )
     mock_cursor.execute.assert_any_call("SELECT url_id FROM url WHERE url = ?", ("http://example.com",))
     mock_cursor.execute.assert_any_call(
         "INSERT INTO results (url_id, success, date_time_stamp) VALUES (?, ?, ?)",


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes to the `checker/save_results.py` file to enhance the functionality of saving URL check results to a database. Additionally, corresponding tests have been updated in `checker/tests/test_save_results.py` to cover the new functionality. The most important changes include the addition of a new function to update the results table, modifications to the `save_results` function, and updates to the test cases.

Enhancements to database operations:

* [`checker/save_results.py`](diffhunk://#diff-d47b12064259fce52114f1c69c3726ab1d8accb6766755a24ec3d34eedfb90a0L20-R55): Added `update_results_table` function to handle inserting or updating URL check results in the database.
* [`checker/save_results.py`](diffhunk://#diff-d47b12064259fce52114f1c69c3726ab1d8accb6766755a24ec3d34eedfb90a0L11-R12): Modified `save_results` function to call `update_results_table` for each result and pass the database connection to `create_tables_if_not_exist`. [[1]](diffhunk://#diff-d47b12064259fce52114f1c69c3726ab1d8accb6766755a24ec3d34eedfb90a0L11-R12) [[2]](diffhunk://#diff-d47b12064259fce52114f1c69c3726ab1d8accb6766755a24ec3d34eedfb90a0L20-R55)
* [`checker/save_results.py`](diffhunk://#diff-d47b12064259fce52114f1c69c3726ab1d8accb6766755a24ec3d34eedfb90a0R82): Updated `create_tables_if_not_exist` function to accept a `Connection` parameter and commit changes after creating tables.

Updates to test cases:

* [`checker/tests/test_save_results.py`](diffhunk://#diff-96c052d0353b1912a7b7a4c49ed837f36e628fd0c14e2a8a9ac06ec8c1c7e267L4-R12): Updated `test_save_results` to mock `update_results_table` and verify it is called correctly. [[1]](diffhunk://#diff-96c052d0353b1912a7b7a4c49ed837f36e628fd0c14e2a8a9ac06ec8c1c7e267L4-R12) [[2]](diffhunk://#diff-96c052d0353b1912a7b7a4c49ed837f36e628fd0c14e2a8a9ac06ec8c1c7e267L29-R43)
* [`checker/tests/test_save_results.py`](diffhunk://#diff-96c052d0353b1912a7b7a4c49ed837f36e628fd0c14e2a8a9ac06ec8c1c7e267R58-R83): Added `test_update_results_table` to test the new `update_results_table` function.

Fixes #191 
