### PR TITLE
refactor: Update Output File Path

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -12,7 +12,7 @@ run:
 
 # Run the checker with the default full example
 run-with-defaults:
-    INPUT_OUTPUT_FILE_PATH="status-checker-output.db" \
+    INPUT_DATABASE_FILE_PATH="status-checker-database.db" \
     INPUT_CONFIG_FILE_PATH="examples/full_example.json" \
     poetry run python -m checker
 
@@ -59,7 +59,7 @@ docker-build:
 docker-run:
     docker run \
         --env INPUT_CONFIG_FILE_PATH="examples/full_example.json" \
-        --env INPUT_OUTPUT_FILE_PATH="status-checker-output.sqlite" \
+        --env INPUT_DATABASE_FILE_PATH="status-checker-database.sqlite" \
         --volume "$(pwd)/examples:/examples" \
         --rm jackplowman/project-status-checker:latest
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The GitHub Action is designed to be used in a workflow.
   uses: jackplowman/project-status-checker@latest
   with:
     config_file_path: "status-checker-config.json"
-    output_file_path: "status-checker-output.db"
+    database_file_path: "status-checker-database.db"
 ```
 
 #### Inputs
@@ -40,7 +40,7 @@ The GitHub Action is designed to be used in a workflow.
 | Name               | Description                        | Required | Default                      |
 | ------------------ | ---------------------------------- | -------- | ---------------------------- |
 | `config_file_path` | The path to the configuration file | No       | `status-checker-config.json` |
-| `output_file_path` | The path to the output file        | No       | `status-checker-output.db`   |
+| `database_file_path` | The path to the database file        | No       | `status-checker-database.db`   |
 
 ### Configuration Examples
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ The GitHub Action is designed to be used in a workflow.
 
 #### Inputs
 
-| Name               | Description                        | Required | Default                      |
-| ------------------ | ---------------------------------- | -------- | ---------------------------- |
-| `config_file_path` | The path to the configuration file | No       | `status-checker-config.json` |
-| `database_file_path` | The path to the database file        | No       | `status-checker-database.db`   |
+| Name                 | Description                        | Required | Default                      |
+| -------------------- | ---------------------------------- | -------- | ---------------------------- |
+| `config_file_path`   | The path to the configuration file | No       | `status-checker-config.json` |
+| `database_file_path` | The path to the database file      | No       | `status-checker-database.db` |
 
 ### Configuration Examples
 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: "Path to the configuration file, configuration file must be created before running the action"
     required: false
     default: "status-checker-config.json"
-  output_file_path:
-    description: "Path to the output file, if file does not exist it will be created"
+  database_file_path:
+    description: "Path to the database file, if file does not exist it will be created"
     required: false
-    default: "status-checker-output.db"
+    default: "status-checker-database.db"

--- a/checker/application_configuration.py
+++ b/checker/application_configuration.py
@@ -6,15 +6,15 @@ class ApplicationConfiguration:
     """Configuration class to handle the checker configuration."""
 
     config_file_path: str
-    output_file_path: str
+    database_file_path: str
 
     def __init__(self) -> None:
         """Initialize the ApplicationConfiguration class."""
         self.config_file_path = self.get_and_check_for_value("INPUT_CONFIG_FILE_PATH")
-        self.output_file_path = self.get_and_check_for_value("INPUT_OUTPUT_FILE_PATH")
+        self.database_file_path = self.get_and_check_for_value("INPUT_DATABASE_FILE_PATH")
 
     def get_and_check_for_value(self: Self, key: str) -> str:
-        """Get a valINPUT_OUTPUT_FILE_PATHue from the action input and check it has been set.
+        """Get a value from the action input and check it has been set.
 
         Args:
             key (str): The key to get the value for.

--- a/checker/save_results.py
+++ b/checker/save_results.py
@@ -16,7 +16,7 @@ def save_results(application_configuration: ApplicationConfiguration, results: l
         application_configuration (ApplicationConfiguration): The application configuration.
         results (list[URLCheckResult]): The list of URL check results.
     """
-    with connect(application_configuration.output_file_path) as connection:
+    with connect(application_configuration.database_file_path) as connection:
         cursor = connection.cursor()
         create_tables_if_not_exist(connection, cursor)
         for result in results:

--- a/checker/tests/test_application_configuration.py
+++ b/checker/tests/test_application_configuration.py
@@ -6,11 +6,11 @@ from checker.application_configuration import ApplicationConfiguration
 def test_application_configuration() -> None:
     # Arrange
     environ["INPUT_CONFIG_FILE_PATH"] = config_file_path = "abc/def/ghi/some_file.txt"
-    environ["INPUT_OUTPUT_FILE_PATH"] = output_file_path = "jkl/mno/pqr/some_output_file.txt"
+    environ["INPUT_DATABASE_FILE_PATH"] = database_file_path = "jkl/mno/pqr/some_database_file.txt"
     configuration = ApplicationConfiguration()
     # Assert
     assert configuration.config_file_path == config_file_path
-    assert configuration.output_file_path == output_file_path
+    assert configuration.database_file_path == database_file_path
     # Clean Up
     del environ["INPUT_CONFIG_FILE_PATH"]
-    del environ["INPUT_OUTPUT_FILE_PATH"]
+    del environ["INPUT_DATABASE_FILE_PATH"]

--- a/checker/tests/test_save_results.py
+++ b/checker/tests/test_save_results.py
@@ -15,7 +15,7 @@ def test_save_results(mock_update_results_table: MagicMock, mock_connect: MagicM
     mock_connection = mock_connect.return_value.__enter__.return_value
     mock_cursor = mock_connection.cursor.return_value
     mock_application_configuration = MagicMock(spec=ApplicationConfiguration)
-    mock_application_configuration.output_file_path = "dummy_path"
+    mock_application_configuration.database_file_path = "dummy_path"
     mock_results = [
         MagicMock(spec=URLCheckResult),
         MagicMock(spec=URLCheckResult),

--- a/run.sh
+++ b/run.sh
@@ -9,8 +9,3 @@ fi
 
 # Run the checker
 python -m checker
-
-# if [ "$CI" = "true" ]; then
-#   # if running in GitHub Actions, copy the output to the output directory
-#   cp original_files github/workspace/output_files
-# fi


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes to rename the `output_file_path` to `database_file_path` across multiple files and update related documentation and tests. The most important changes include modifications to the `Justfile`, `README.md`, `action.yml`, and various Python files.

Updates to file paths:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL15-R15): Renamed `INPUT_OUTPUT_FILE_PATH` to `INPUT_DATABASE_FILE_PATH` in `run-with-defaults` and `docker-build` commands. [[1]](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL15-R15) [[2]](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL62-R62)

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R43): Updated the example configuration and input descriptions to use `database_file_path` instead of `output_file_path`.

Configuration and code updates:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L15-R18): Changed `output_file_path` to `database_file_path` in action inputs.
* [`checker/application_configuration.py`](diffhunk://#diff-87340611a1d2fadc8b66b44f9c0af9987eaa7acf8833fe2a87565b47a2df816cL9-R17): Updated the `ApplicationConfiguration` class to use `database_file_path` instead of `output_file_path`.
* [`checker/save_results.py`](diffhunk://#diff-d47b12064259fce52114f1c69c3726ab1d8accb6766755a24ec3d34eedfb90a0L19-R19): Modified the `save_results` function to reference `database_file_path` instead of `output_file_path`.

Test updates:

* [`checker/tests/test_application_configuration.py`](diffhunk://#diff-f21ac4fa2a1f397300d7bf9ef9ea0c910c59f4bf56cd362ce060b03cdc80ff8cL9-R16): Adjusted tests to reflect the change from `output_file_path` to `database_file_path`.
* [`checker/tests/test_save_results.py`](diffhunk://#diff-96c052d0353b1912a7b7a4c49ed837f36e628fd0c14e2a8a9ac06ec8c1c7e267L18-R18): Updated mock configurations to use `database_file_path`.

Cleanup:

* [`run.sh`](diffhunk://#diff-d31ce0453051853c17ba2a5225b3d1bfab548e095bab0967d6acfd1b3ce1b35dL12-L16): Removed commented-out code related to copying output files in CI environments.

Fixes #198 