### PR TITLE
build: Add URL Alias

### DIFF
--- a/checker/checker.py
+++ b/checker/checker.py
@@ -45,7 +45,7 @@ def load_configuration_file(application_configuration: ApplicationConfiguration)
     with Path(found_path).open() as file:
         file_contents = load(file)
     logger.debug("Loaded configuration file", file_contents=file_contents)
-    return [URL(url["url"], url["allowed_status_code"]) for url in file_contents["urls"]]
+    return [URL(url["alias"], url["url"], url["allowed_status_code"]) for url in file_contents["urls"]]
 
 
 def check_urls(urls: list[URL]) -> list[URLCheckResult]:

--- a/checker/save_results.py
+++ b/checker/save_results.py
@@ -36,7 +36,7 @@ def update_results_table(result: URLCheckResult, connection: Connection, cursor:
     url_id = cursor.fetchone()
     # If the URL is not in the database, add it
     if url_id is None:
-        cursor.execute("INSERT INTO url (alias, url) VALUES (?, ?)", (result.url.address, result.url.address))
+        cursor.execute("INSERT INTO url (alias, url) VALUES (?, ?)", (result.url.alias, result.url.address))
         cursor.execute("SELECT url_id FROM url WHERE url = ?", (result.url.address,))
         url_id = cursor.fetchone()
     # Add the result to the results table
@@ -61,7 +61,7 @@ def create_tables_if_not_exist(connection: Connection, cursor: Cursor) -> None:
     if cursor.fetchone() is None:
         logger.debug("Creating table url")
         cursor.execute("CREATE TABLE url (url_id INTEGER PRIMARY KEY, alias TEXT NOT NULL, url TEXT NOT NULL)")
-        logger.debug("Created table results")
+        logger.debug("Created table url")
         tables_created.append("url")
         # Check if results table exists
     cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='results'")

--- a/checker/tests/test_checker.py
+++ b/checker/tests/test_checker.py
@@ -38,8 +38,8 @@ def test_load_configuration_file(mock_load: MagicMock, mock_open: MagicMock, moc
     """Test the load_configuration_file function."""
     mock_file_contents = {
         "urls": [
-            {"url": "http://example.com", "allowed_status_code": 200},
-            {"url": "http://example.org", "allowed_status_code": 404},
+            {"alias": "1", "url": "http://example.com", "allowed_status_code": 200},
+            {"alias": "2", "url": "http://example.org", "allowed_status_code": 404},
         ]
     }
     mock_load.return_value = mock_file_contents

--- a/checker/tests/test_github_action_summary.py
+++ b/checker/tests/test_github_action_summary.py
@@ -14,8 +14,8 @@ def test_generate_action_summary(mock_open: MagicMock, mock_getenv: MagicMock) -
     """Test the generate_action_summary function."""
     # Arrange
     environ["GITHUB_STEP_SUMMARY"] = "dummy_path"
-    url1 = URL("http://example.com", 200)
-    url2 = URL("http://example.org", 404)
+    url1 = URL("example1", "http://example.com", 200)
+    url2 = URL("example2", "http://example.org", 404)
     result1 = URLCheckResult(url1, 200, True)  # noqa: FBT003
     result2 = URLCheckResult(url2, 404, True)  # noqa: FBT003
     results = [result1, result2]

--- a/checker/tests/test_save_results.py
+++ b/checker/tests/test_save_results.py
@@ -65,7 +65,8 @@ def test_update_results_table(mock_datetime: MagicMock) -> None:
     mock_cursor = MagicMock()
     mock_connection = MagicMock()
     mock_result = MagicMock()
-    mock_result.url.address = "http://example.com"
+    mock_result.url.alias = alias = "example"
+    mock_result.url.address = address = "http://example.com"
     mock_result.success = True
     mock_datetime.now.return_value = "2023-10-10T10:10:10Z"
     # Simulate URL not in database
@@ -73,11 +74,9 @@ def test_update_results_table(mock_datetime: MagicMock) -> None:
     # Act
     update_results_table(mock_result, mock_connection, mock_cursor)
     # Assert
-    mock_cursor.execute.assert_any_call("SELECT url_id FROM url WHERE url = ?", ("http://example.com",))
-    mock_cursor.execute.assert_any_call(
-        "INSERT INTO url (alias, url) VALUES (?, ?)", ("http://example.com", "http://example.com")
-    )
-    mock_cursor.execute.assert_any_call("SELECT url_id FROM url WHERE url = ?", ("http://example.com",))
+    mock_cursor.execute.assert_any_call("SELECT url_id FROM url WHERE url = ?", (address,))
+    mock_cursor.execute.assert_any_call("INSERT INTO url (alias, url) VALUES (?, ?)", (alias, address))
+    mock_cursor.execute.assert_any_call("SELECT url_id FROM url WHERE url = ?", (address,))
     mock_cursor.execute.assert_any_call(
         "INSERT INTO results (url_id, success, date_time_stamp) VALUES (?, ?, ?)",
         (1, True, "2023-10-10T10:10:10Z"),

--- a/checker/tests/test_url.py
+++ b/checker/tests/test_url.py
@@ -4,17 +4,17 @@ from checker.url import URL
 
 
 @pytest.mark.parametrize(
-    ("address", "allowed_status_code"),
+    ("alias", "address", "allowed_status_code"),
     [
-        ("http://www.google.com", 200),
-        ("https://www.google.com", 200),
-        ("http://www.google.com", 404),
-        ("http://www.google.com", 500),
+        ("google1", "http://www.google.com", 200),
+        ("google2", "https://www.google.com", 200),
+        ("google3", "http://www.google.com", 404),
+        ("google4", "http://www.google.com", 500),
     ],
 )
-def test_url(address: str, allowed_status_code: int) -> None:
+def test_url(alias: str, address: str, allowed_status_code: int) -> None:
     # Act
-    url = URL(address, allowed_status_code)
+    url = URL(alias, address, allowed_status_code)
     # Assert
     assert url.address == address
     assert url.allowed_status_code == allowed_status_code

--- a/checker/tests/test_url_check_result.py
+++ b/checker/tests/test_url_check_result.py
@@ -5,15 +5,15 @@ from checker.url_check_result import URLCheckResult
 
 
 @pytest.mark.parametrize(
-    ("url_address", "status_code", "success"),
+    ("alias", "url_address", "status_code", "success"),
     [
-        ("http://example.com", 200, True),
-        ("http://example.com", 404, False),
+        ("example1", "http://example.com", 200, True),
+        ("example2", "http://example.com", 404, False),
     ],
 )
-def test_url_check_result(url_address: str, status_code: int, success: bool) -> None:  # noqa: FBT001
+def test_url_check_result(alias: str, url_address: str, status_code: int, success: bool) -> None:  # noqa: FBT001
     # Arrange
-    url = URL(url_address, status_code)
+    url = URL(alias, url_address, status_code)
     # Act
     result = URLCheckResult(url, status_code, success)
     # Assert

--- a/checker/url.py
+++ b/checker/url.py
@@ -5,5 +5,6 @@ from dataclasses import dataclass
 class URL:
     """URL class."""
 
+    alias: str
     address: str
     allowed_status_code: int

--- a/examples/full_example.json
+++ b/examples/full_example.json
@@ -1,6 +1,7 @@
 {
   "urls": [
     {
+      "alias": "google",
       "url": "https://www.google.com",
       "allowed_status_code": 200
     }


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces the concept of an alias for URLs across various parts of the codebase. The changes include updates to the main functionality, database interactions, and corresponding tests to accommodate the new `alias` field for URLs.

### Main Functionality and Database Changes:
* [`checker/checker.py`](diffhunk://#diff-ab329e1093d96bea1fd0133af026a4ae38bf48fb7d5b3a77b42652523c8934e1L48-R48): Modified the `load_configuration_file` function to include the `alias` field when loading URLs from the configuration file.
* [`checker/save_results.py`](diffhunk://#diff-d47b12064259fce52114f1c69c3726ab1d8accb6766755a24ec3d34eedfb90a0L39-R39): Updated the `update_results_table` function to insert and handle the `alias` field for URLs in the database.
* [`checker/save_results.py`](diffhunk://#diff-d47b12064259fce52114f1c69c3726ab1d8accb6766755a24ec3d34eedfb90a0L64-R64): Corrected the log message in the `create_tables_if_not_exist` function to accurately reflect the creation of the `url` table.

### Test Updates:
* [`checker/tests/test_checker.py`](diffhunk://#diff-fc185135883e7db9de3ebdab2c44b8af927518dc2765e19221f225bba97a8c2eL41-R42): Adjusted the test for `load_configuration_file` to include the `alias` field in mock data.
* [`checker/tests/test_github_action_summary.py`](diffhunk://#diff-4a32d322185d7945a7e276a3fbcabfa74fdd9e44dfd08ca14d7e0ee02940931aL17-R18): Modified the test for `generate_action_summary` to use URLs with aliases.
* [`checker/tests/test_save_results.py`](diffhunk://#diff-96c052d0353b1912a7b7a4c49ed837f36e628fd0c14e2a8a9ac06ec8c1c7e267L68-R79): Updated the test for `update_results_table` to handle the `alias` field.
* [`checker/tests/test_url.py`](diffhunk://#diff-44147ddb3f60165fd5069ae400207268ce49af9f1e65c38e6d5a8171b91df439L7-R17): Changed the parameterized test for the `URL` class to include the `alias` field.
* [`checker/tests/test_url_check_result.py`](diffhunk://#diff-d7a1a96c7ec171ed569f0603d6b89489628d87b0484373cc7fcbd1660a74074fL8-R16): Updated the parameterized test for `URLCheckResult` to include the `alias` field.

### Model Update:
* [`checker/url.py`](diffhunk://#diff-b1732c002e1073449017622d7342f6e2553666c26f832e9f6903a667c250f40aR8): Added the `alias` attribute to the `URL` class definition.

### Example Configuration:
* [`examples/full_example.json`](diffhunk://#diff-64ca3e50f573a104b2ce99c3d0f4340d99baeae5ba7ec440fc93eb4fc8aa11a8R4): Added the `alias` field to the example URL configuration.

Fixes #157 
