### PR TITLE
build: Add Release Package Workflow

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,48 @@
+name: Release Package
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-package:
+    name: Build and Push Package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.6.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6.10.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1.4.4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a GitHub Actions workflow to automate the release of Docker packages. The workflow is triggered by the creation of new tags and includes steps for checking out the repository, logging into the container registry, extracting metadata, building and pushing the Docker image, and generating artifact attestations.

Key changes include:

* Added a new GitHub Actions workflow file `.github/workflows/release-package.yml` to automate the release process for Docker packages.

Workflow details:

* The workflow is named "Release Package" and triggers on pushes to tags matching the pattern "v*".
* Environment variables `REGISTRY` and `IMAGE_NAME` are set for use in the workflow.
* The job `build-and-push-package` runs on `ubuntu-latest` and includes steps for repository checkout, Docker login, metadata extraction, Docker image build and push, and artifact attestation generation.

Fixes #114 
