### PR TITLE
chore: Fix Dependabot Config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
       - "/"
       - ".github/actions/setup-dependencies"
       - ".github/actions/local"
-    directory: "/"
     commit-message:
       prefix: "deps(github-actions)"
     schedule:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/dependabot.yml` file. The change removes the `directory` key from the `updates` section.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L9): Removed the `directory` key from the `updates` section.
