### PR TITLE
ci: Run Tests After Job Built

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -46,3 +46,20 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+  test-action:
+    name: Test Action
+    needs: build-and-push-package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Run GitHub Stats Analyser (pre-built image)
+        uses: ./
+        with:
+          config_file_path: "examples/full_example.json"
+          database_file_path: "status-checker-database.db"
+      - name: Test Output
+        run: tests/test_database.sh


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a significant addition to the GitHub Actions workflow configuration in `.github/workflows/release-package.yml`. The most important change is the introduction of a new job to test the action after the package has been built and pushed.

Changes to GitHub Actions workflow:

* [`.github/workflows/release-package.yml`](diffhunk://#diff-3099c6260c6951cb01f86e1ae6d3445e822dfd243571b51a1737ec2cee3a7e56R49-R65): Added a new job `test-action` that runs after `build-and-push-package`. This job checks out the repository, runs the GitHub Stats Analyser using a pre-built image, and then executes a test script to verify the output.

Fixes #210 
