### PR TITLE
ci: Update CodeLimit Action and Permissions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -149,6 +149,8 @@ jobs:
   run-code-limit:
     name: Run Code Limit
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -158,7 +160,6 @@ jobs:
         uses: getcodelimit/codelimit-action@8ee70f8d3d5b984130e46fb8ccbe229f5e1d68d0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          upload: true
 
   run-local-action:
     name: Run Local Project Status Checker Action

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -151,6 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -157,9 +157,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: "Run Code Limit"
-        uses: getcodelimit/codelimit-action@8ee70f8d3d5b984130e46fb8ccbe229f5e1d68d0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        uses: getcodelimit/codelimit-action@v1
 
   run-local-action:
     name: Run Local Project Status Checker Action


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the GitHub Actions workflow file `.github/workflows/code-checks.yml` to update permissions and modify the `Run Code Limit` action.

Changes to GitHub Actions workflow:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R152-R161): Added `contents: write` and `pull-requests: write` permissions to the `run-code-limit` job to ensure the action can write to the repository.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R152-R161): Updated the `Run Code Limit` action to use `getcodelimit/codelimit-action@v1` instead of a specific commit hash.

Fixes #226 
