### PR TITLE
ci: Add Zizmor Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -147,7 +147,7 @@ jobs:
         uses: github/codeql-action/analyze@v3.27.0
 
   run-code-limit:
-    name: Run Code Limit
+    name: Run CodeLimit
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -157,8 +157,33 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-      - name: "Run Code Limit"
+      - name: "Run CodeLimit"
         uses: getcodelimit/codelimit-action@v1
+
+  run-zizmor:
+    name: Check GitHub Actions with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4.2.0
+        with:
+          version: "latest"
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3.27.9
+        with:
+          sarif_file: results.sarif
+          category: zizmor
 
   run-local-action:
     name: Run Local Project Status Checker Action


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job to the GitHub Actions workflow for running a security check with zizmor. The most important change is the addition of the `run-zizmor` job to the `.github/workflows/code-checks.yml` file.

### Additions to GitHub Actions workflow:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R163-R187): Added a new job `run-zizmor` to check GitHub Actions with zizmor, including steps for checking out the repository, installing the latest version of `uv`, running zizmor, and uploading the SARIF file.

Fixes #234 
