### PR TITLE
chore: Fix Zizmor Warnings

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -9,13 +9,13 @@ on:
 permissions:
   contents: read
   packages: read
-  statuses: write
-  security-events: write
 
 jobs:
   check-code-quality:
     name: Check Code Quality
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -43,6 +43,8 @@ jobs:
   check-python-code-format-and-quality:
     name: Check Python Code Format and Quality
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -129,6 +131,8 @@ jobs:
   run-codeql-analysis:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, synchronize]
 
 permissions:
-  pull-requests: write
+  contents: read
 
 jobs:
   check-pull-request-title:
@@ -19,6 +19,8 @@ jobs:
   labeller:
     name: Label Pull Request
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Label Pull Request
         uses: actions/labeler@v5.0.0


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the GitHub Actions workflows to adjust permissions for various jobs. The most important changes include modifying the permissions for code quality checks, CodeQL analysis, and pull request tasks.

### Adjustments to permissions in workflows:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L12-R18): Removed `statuses` and `security-events` write permissions from the global scope and added them to specific jobs (`check-code-quality`, `check-python-code-format-and-quality`, `run-codeql-analysis`). [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L12-R18) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R46-R47) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R134-R135)
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL8-R8): Changed `pull-requests` write permission to `contents` read permission in the global scope and added `pull-requests` write permission to the `labeller` job. [[1]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL8-R8) [[2]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfR22-R23)
