### PR TITLE
chore: Set some job runners to ubuntu-22.04

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -79,7 +79,7 @@ jobs:
 
   check-markdown-links:
     name: Check Markdown links
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -193,7 +193,7 @@ jobs:
 
   run-local-action:
     name: Run Local Project Status Checker Action
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the GitHub Actions workflows to ensure compatibility and stability by updating the runner version.

Updates to GitHub Actions workflows:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L82-R82): Updated the `runs-on` parameter for the `check-markdown-links` job to use `ubuntu-22.04` instead of `ubuntu-latest`.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L196-R196): Updated the `runs-on` parameter for the `run-local-action` job to use `ubuntu-22.04` instead of `ubuntu-latest`.