### PR TITLE
ci: Schedule Code Checks to Run Daily

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize]
+  schedule:
+    - cron: "0 0 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/code-checks.yml` file. The change schedules the code checks workflow to run daily at midnight using a cron job.

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R8-R9): Added a cron schedule to run the workflow daily at midnight.