### PR TITLE
ci: Rename GitHub Actions Steps

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       statuses: write
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -48,7 +48,7 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -85,7 +85,7 @@ jobs:
     name: Check Markdown links
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -103,7 +103,7 @@ jobs:
     name: Check Justfile Format
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -117,7 +117,7 @@ jobs:
     name: Run Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -144,7 +144,7 @@ jobs:
       matrix:
         language: [python, actions]
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -164,7 +164,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -199,7 +199,7 @@ jobs:
     name: Run Local Project Status Checker Action
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -222,7 +222,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: run-local-action
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -47,7 +47,7 @@ jobs:
     name: Dependency Review
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -59,7 +59,7 @@ jobs:
     name: Build Docker Image and Run
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -19,7 +19,7 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -55,7 +55,7 @@ jobs:
     needs: build-and-push-package
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,7 +15,7 @@ jobs:
   configure-labels:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the GitHub Actions workflows to improve clarity by renaming the "Checkout" step to "Checkout Repository". The changes span multiple workflow files and ensure consistency across different job steps.

Changes to improve clarity in GitHub Actions workflows:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L22-R22): Renamed "Checkout" step to "Checkout Repository" in multiple job steps, including "Check Markdown links", "Check Justfile Format", "Run Unit Tests", and others. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L22-R22) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L51-R51) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L88-R88) [[4]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L106-R106) [[5]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L120-R120) [[6]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L147-R147) [[7]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L167-R167) [[8]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L202-R202) [[9]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L225-R225)
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL50-R50): Renamed "Checkout" step to "Checkout Repository" in job steps "Dependency Review" and "Build Docker Image and Run". [[1]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL50-R50) [[2]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL62-R62)
* [`.github/workflows/release-package.yml`](diffhunk://#diff-3099c6260c6951cb01f86e1ae6d3445e822dfd243571b51a1737ec2cee3a7e56L22-R22): Renamed "Checkout" step to "Checkout Repository" in job steps related to package release. [[1]](diffhunk://#diff-3099c6260c6951cb01f86e1ae6d3445e822dfd243571b51a1737ec2cee3a7e56L22-R22) [[2]](diffhunk://#diff-3099c6260c6951cb01f86e1ae6d3445e822dfd243571b51a1737ec2cee3a7e56L58-R58)
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L18-R18): Renamed "Checkout" step to "Checkout Repository" in the "configure-labels" job step.