### PR TITLE
chore: Refactor Git Hooks

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
       - name: Check Python Code Quality (Ruff)
-        run: just ruff-lint
+        run: just ruff-lint-check
         env:
           RUFF_OUTPUT_FORMAT: "sarif"
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
@@ -71,7 +71,7 @@ jobs:
         env:
           RUFF_OUTPUT_FORMAT: "github"
       - name: Check Python Code Quality (Ruff)
-        run: just ruff-lint
+        run: just ruff-lint-check
         env:
           RUFF_OUTPUT_FORMAT: "github"
       - name: Check Python Code for Dead Code (Vulture)

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -67,7 +67,7 @@ jobs:
           sarif_file: ruff-results.sarif
           wait-for-processing: true
       - name: Check Python Code Format (Ruff)
-        run: just ruff-format
+        run: just ruff-format-check
         env:
           RUFF_OUTPUT_FORMAT: "github"
       - name: Check Python Code Quality (Ruff)

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.13-alpine AS builder
 WORKDIR /
 
 COPY pyproject.toml uv.lock ./
-RUN pip install --no-cache-dir uv==0.6.2 && \
+RUN pip install --no-cache-dir uv==0.6.3 && \
   uv export --format=requirements-txt > requirements.txt
 
 FROM python:3.13-alpine AS checker

--- a/Justfile
+++ b/Justfile
@@ -81,7 +81,7 @@ ruff-checks:
     just ruff-lint-check
 
 # Check for Ruff issues
-ruff-lint:
+ruff-lint-check:
     uv run ruff check .
 
 # Fix Ruff lint issues
@@ -89,7 +89,7 @@ ruff-lint-fix:
     uv run ruff check . --fix
 
 # Check for Ruff format issues
-ruff-format:
+ruff-format-check:
     uv run ruff format --check .
 
 # Fix Ruff format issues

--- a/Justfile
+++ b/Justfile
@@ -75,6 +75,11 @@ ruff-fix:
     just ruff-format-fix
     just ruff-lint-fix
 
+# Check for all Ruff issues
+ruff-checks:
+    just ruff-format-check
+    just ruff-lint-check
+
 # Check for Ruff issues
 ruff-lint:
     uv run ruff check .
@@ -118,6 +123,13 @@ format:
 
 format-check:
     just --fmt --check --unstable
+
+# ------------------------------------------------------------------------------
+# gitleaks
+# ------------------------------------------------------------------------------
+
+gitleaks-detect:
+    gitleaks detect --source . > /dev/null
 
 # ------------------------------------------------------------------------------
 # Git Hooks

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,13 +1,38 @@
 #!/bin/bash
 set -e +x
 
-# shellcheck disable=SC2045,SC2028,SC2086,SC2206,SC2128
-for script in $(ls -1 githooks/pre-commit-scripts/*.sh 2>/dev/null); do
-  ts=$SECONDS
-  echo "Running githook: $script"
-  bash $script
-  te=($SECONDS - $ts)
-  echo "Script Took (${te}s)"
-done
+echo "Running pre-commit hooks checks"
 
-printf "pre-commit completed successfully"
+# Run gitleaks checks
+if ! just -q gitleaks-detect; then
+  echo "Warning: gitleaks-detect command failed"
+  exit 1
+else
+  echo "gitleaks checks passed"
+fi
+
+# Run prettier checks
+if ! just -q prettier-check; then
+  echo "Warning: prettier-check command failed"
+  exit 1
+else
+  echo "prettier checks passed"
+fi
+
+# Run just format checks
+if ! just -q format-check; then
+  echo "Warning: format-check command failed"
+  exit 1
+else
+  echo "just format checks passed"
+fi
+
+# Python checks
+if ! just -q ruff-checks; then
+  echo "Warning: ruff-checks command failed"
+  exit 1
+else
+  echo "ruff checks passed"
+fi
+
+echo "All pre-commit hooks checks passed"

--- a/githooks/pre-commit-scripts/gitleaks.sh
+++ b/githooks/pre-commit-scripts/gitleaks.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e +x
-
-gitleaks detect --source .

--- a/githooks/pre-commit-scripts/justfile.sh
+++ b/githooks/pre-commit-scripts/justfile.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e +x
-
-just format

--- a/githooks/pre-commit-scripts/prettier.sh
+++ b/githooks/pre-commit-scripts/prettier.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e +x
-
-just prettier-format

--- a/githooks/pre-commit-scripts/python.sh
+++ b/githooks/pre-commit-scripts/python.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e +x
-
-# Check if there are any changes in the watched folder
-if git diff --cached --name-only | grep -q "^checker/"; then
-  just install
-  just ruff-fix
-fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,23 +4,23 @@ name = "project-status-checker"
 dynamic = ["version"]
 requires-python = ">=3.13"
 dependencies = [
-  "structlog==24.4.0",
+  "structlog==25.1.0",
   "requests==2.32.3",
   "mdutils==1.6.0; python_version >= '3.13' and python_version < '4.0'",
 ]
 
 [project.optional-dependencies]
 dev = [
-  "ruff==0.9.7",
+  "ruff==0.9.9",
   "pytest==8.3.4",
   "pytest-cov==6.0.0",
   "vulture==2.14",
-  "zizmor==1.3.1",
+  "zizmor==1.4.1",
 ]
 test = ["Markdown==3.7", "beautifulsoup4==4.12.3"]
 
 [tool.uv]
-required-version = "0.6.2"
+required-version = "0.6.3"
 package = false
 
 [tool.setuptools]

--- a/uv.lock
+++ b/uv.lock
@@ -164,10 +164,10 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = "==8.3.4" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==6.0.0" },
     { name = "requests", specifier = "==2.32.3" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.9.7" },
-    { name = "structlog", specifier = "==24.4.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.9.9" },
+    { name = "structlog", specifier = "==25.1.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.14" },
-    { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.3.1" },
+    { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.4.1" },
 ]
 provides-extras = ["dev", "test"]
 
@@ -216,27 +216,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.9.7"
+version = "0.9.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/39/8b/a86c300359861b186f18359adf4437ac8e4c52e42daa9eedc731ef9d5b53/ruff-0.9.7.tar.gz", hash = "sha256:643757633417907510157b206e490c3aa11cab0c087c912f60e07fbafa87a4c6", size = 3669813 }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/c3/418441a8170e8d53d05c0b9dad69760dbc7b8a12c10dbe6db1e1205d2377/ruff-0.9.9.tar.gz", hash = "sha256:0062ed13f22173e85f8f7056f9a24016e692efeea8704d1a5e8011b8aa850933", size = 3717448 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/f3/3a1d22973291226df4b4e2ff70196b926b6f910c488479adb0eeb42a0d7f/ruff-0.9.7-py3-none-linux_armv6l.whl", hash = "sha256:99d50def47305fe6f233eb8dabfd60047578ca87c9dcb235c9723ab1175180f4", size = 11774588 },
-    { url = "https://files.pythonhosted.org/packages/8e/c9/b881f4157b9b884f2994fd08ee92ae3663fb24e34b0372ac3af999aa7fc6/ruff-0.9.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d59105ae9c44152c3d40a9c40d6331a7acd1cdf5ef404fbe31178a77b174ea66", size = 11746848 },
-    { url = "https://files.pythonhosted.org/packages/14/89/2f546c133f73886ed50a3d449e6bf4af27d92d2f960a43a93d89353f0945/ruff-0.9.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f313b5800483770bd540cddac7c90fc46f895f427b7820f18fe1822697f1fec9", size = 11177525 },
-    { url = "https://files.pythonhosted.org/packages/d7/93/6b98f2c12bf28ab9def59c50c9c49508519c5b5cfecca6de871cf01237f6/ruff-0.9.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:042ae32b41343888f59c0a4148f103208bf6b21c90118d51dc93a68366f4e903", size = 11996580 },
-    { url = "https://files.pythonhosted.org/packages/8e/3f/b3fcaf4f6d875e679ac2b71a72f6691a8128ea3cb7be07cbb249f477c061/ruff-0.9.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87862589373b33cc484b10831004e5e5ec47dc10d2b41ba770e837d4f429d721", size = 11525674 },
-    { url = "https://files.pythonhosted.org/packages/f0/48/33fbf18defb74d624535d5d22adcb09a64c9bbabfa755bc666189a6b2210/ruff-0.9.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a17e1e01bee0926d351a1ee9bc15c445beae888f90069a6192a07a84af544b6b", size = 12739151 },
-    { url = "https://files.pythonhosted.org/packages/63/b5/7e161080c5e19fa69495cbab7c00975ef8a90f3679caa6164921d7f52f4a/ruff-0.9.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:7c1f880ac5b2cbebd58b8ebde57069a374865c73f3bf41f05fe7a179c1c8ef22", size = 13416128 },
-    { url = "https://files.pythonhosted.org/packages/4e/c8/b5e7d61fb1c1b26f271ac301ff6d9de5e4d9a9a63f67d732fa8f200f0c88/ruff-0.9.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e63fc20143c291cab2841dbb8260e96bafbe1ba13fd3d60d28be2c71e312da49", size = 12870858 },
-    { url = "https://files.pythonhosted.org/packages/da/cb/2a1a8e4e291a54d28259f8fc6a674cd5b8833e93852c7ef5de436d6ed729/ruff-0.9.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:91ff963baed3e9a6a4eba2a02f4ca8eaa6eba1cc0521aec0987da8d62f53cbef", size = 14786046 },
-    { url = "https://files.pythonhosted.org/packages/ca/6c/c8f8a313be1943f333f376d79724260da5701426c0905762e3ddb389e3f4/ruff-0.9.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88362e3227c82f63eaebf0b2eff5b88990280fb1ecf7105523883ba8c3aaf6fb", size = 12550834 },
-    { url = "https://files.pythonhosted.org/packages/9d/ad/f70cf5e8e7c52a25e166bdc84c082163c9c6f82a073f654c321b4dff9660/ruff-0.9.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0372c5a90349f00212270421fe91874b866fd3626eb3b397ede06cd385f6f7e0", size = 11961307 },
-    { url = "https://files.pythonhosted.org/packages/52/d5/4f303ea94a5f4f454daf4d02671b1fbfe2a318b5fcd009f957466f936c50/ruff-0.9.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d76b8ab60e99e6424cd9d3d923274a1324aefce04f8ea537136b8398bbae0a62", size = 11612039 },
-    { url = "https://files.pythonhosted.org/packages/eb/c8/bd12a23a75603c704ce86723be0648ba3d4ecc2af07eecd2e9fa112f7e19/ruff-0.9.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:0c439bdfc8983e1336577f00e09a4e7a78944fe01e4ea7fe616d00c3ec69a3d0", size = 12168177 },
-    { url = "https://files.pythonhosted.org/packages/cc/57/d648d4f73400fef047d62d464d1a14591f2e6b3d4a15e93e23a53c20705d/ruff-0.9.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:115d1f15e8fdd445a7b4dc9a30abae22de3f6bcabeb503964904471691ef7606", size = 12610122 },
-    { url = "https://files.pythonhosted.org/packages/49/79/acbc1edd03ac0e2a04ae2593555dbc9990b34090a9729a0c4c0cf20fb595/ruff-0.9.7-py3-none-win32.whl", hash = "sha256:e9ece95b7de5923cbf38893f066ed2872be2f2f477ba94f826c8defdd6ec6b7d", size = 9988751 },
-    { url = "https://files.pythonhosted.org/packages/6d/95/67153a838c6b6ba7a2401241fd8a00cd8c627a8e4a0491b8d853dedeffe0/ruff-0.9.7-py3-none-win_amd64.whl", hash = "sha256:3770fe52b9d691a15f0b87ada29c45324b2ace8f01200fb0c14845e499eb0c2c", size = 11002987 },
-    { url = "https://files.pythonhosted.org/packages/63/6a/aca01554949f3a401991dc32fe22837baeaccb8a0d868256cbb26a029778/ruff-0.9.7-py3-none-win_arm64.whl", hash = "sha256:b075a700b2533feb7a01130ff656a4ec0d5f340bb540ad98759b8401c32c2037", size = 10177763 },
+    { url = "https://files.pythonhosted.org/packages/bc/c3/2c4afa9ba467555d074b146d9aed0633a56ccdb900839fb008295d037b89/ruff-0.9.9-py3-none-linux_armv6l.whl", hash = "sha256:628abb5ea10345e53dff55b167595a159d3e174d6720bf19761f5e467e68d367", size = 10027252 },
+    { url = "https://files.pythonhosted.org/packages/33/d1/439e58487cf9eac26378332e25e7d5ade4b800ce1eec7dc2cfc9b0d7ca96/ruff-0.9.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b6cd1428e834b35d7493354723543b28cc11dc14d1ce19b685f6e68e07c05ec7", size = 10840721 },
+    { url = "https://files.pythonhosted.org/packages/50/44/fead822c38281ba0122f1b76b460488a175a9bd48b130650a6fb6dbcbcf9/ruff-0.9.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5ee162652869120ad260670706f3cd36cd3f32b0c651f02b6da142652c54941d", size = 10161439 },
+    { url = "https://files.pythonhosted.org/packages/11/ae/d404a2ab8e61ddf6342e09cc6b7f7846cce6b243e45c2007dbe0ca928a5d/ruff-0.9.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3aa0f6b75082c9be1ec5a1db78c6d4b02e2375c3068438241dc19c7c306cc61a", size = 10336264 },
+    { url = "https://files.pythonhosted.org/packages/6a/4e/7c268aa7d84cd709fb6f046b8972313142cffb40dfff1d2515c5e6288d54/ruff-0.9.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:584cc66e89fb5f80f84b05133dd677a17cdd86901d6479712c96597a3f28e7fe", size = 9908774 },
+    { url = "https://files.pythonhosted.org/packages/cc/26/c618a878367ef1b76270fd027ca93692657d3f6122b84ba48911ef5f2edc/ruff-0.9.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abf3369325761a35aba75cd5c55ba1b5eb17d772f12ab168fbfac54be85cf18c", size = 11428127 },
+    { url = "https://files.pythonhosted.org/packages/d7/9a/c5588a93d9bfed29f565baf193fe802fa676a0c837938137ea6cf0576d8c/ruff-0.9.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:3403a53a32a90ce929aa2f758542aca9234befa133e29f4933dcef28a24317be", size = 12133187 },
+    { url = "https://files.pythonhosted.org/packages/3e/ff/e7980a7704a60905ed7e156a8d73f604c846d9bd87deda9cabfa6cba073a/ruff-0.9.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:18454e7fa4e4d72cffe28a37cf6a73cb2594f81ec9f4eca31a0aaa9ccdfb1590", size = 11602937 },
+    { url = "https://files.pythonhosted.org/packages/24/78/3690444ad9e3cab5c11abe56554c35f005b51d1d118b429765249095269f/ruff-0.9.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fadfe2c88724c9617339f62319ed40dcdadadf2888d5afb88bf3adee7b35bfb", size = 13771698 },
+    { url = "https://files.pythonhosted.org/packages/6e/bf/e477c2faf86abe3988e0b5fd22a7f3520e820b2ee335131aca2e16120038/ruff-0.9.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6df104d08c442a1aabcfd254279b8cc1e2cbf41a605aa3e26610ba1ec4acf0b0", size = 11249026 },
+    { url = "https://files.pythonhosted.org/packages/f7/82/cdaffd59e5a8cb5b14c408c73d7a555a577cf6645faaf83e52fe99521715/ruff-0.9.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d7c62939daf5b2a15af48abbd23bea1efdd38c312d6e7c4cedf5a24e03207e17", size = 10220432 },
+    { url = "https://files.pythonhosted.org/packages/fe/a4/2507d0026225efa5d4412b6e294dfe54725a78652a5c7e29e6bd0fc492f3/ruff-0.9.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:9494ba82a37a4b81b6a798076e4a3251c13243fc37967e998efe4cce58c8a8d1", size = 9874602 },
+    { url = "https://files.pythonhosted.org/packages/d5/be/f3aab1813846b476c4bcffe052d232244979c3cd99d751c17afb530ca8e4/ruff-0.9.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4efd7a96ed6d36ef011ae798bf794c5501a514be369296c672dab7921087fa57", size = 10851212 },
+    { url = "https://files.pythonhosted.org/packages/8b/45/8e5fd559bea0d2f57c4e12bf197a2fade2fac465aa518284f157dfbca92b/ruff-0.9.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:ab90a7944c5a1296f3ecb08d1cbf8c2da34c7e68114b1271a431a3ad30cb660e", size = 11327490 },
+    { url = "https://files.pythonhosted.org/packages/42/55/e6c90f13880aeef327746052907e7e930681f26a164fe130ddac28b08269/ruff-0.9.9-py3-none-win32.whl", hash = "sha256:6b4c376d929c25ecd6d87e182a230fa4377b8e5125a4ff52d506ee8c087153c1", size = 10227912 },
+    { url = "https://files.pythonhosted.org/packages/35/b2/da925693cb82a1208aa34966c0f36cb222baca94e729dd22a587bc22d0f3/ruff-0.9.9-py3-none-win_amd64.whl", hash = "sha256:837982ea24091d4c1700ddb2f63b7070e5baec508e43b01de013dc7eff974ff1", size = 11355632 },
+    { url = "https://files.pythonhosted.org/packages/31/d8/de873d1c1b020d668d8ec9855d390764cb90cf8f6486c0983da52be8b7b7/ruff-0.9.9-py3-none-win_arm64.whl", hash = "sha256:3ac78f127517209fe6d96ab00f3ba97cafe38718b23b1db3e96d8b2d39e37ddf", size = 10435860 },
 ]
 
 [[package]]
@@ -250,11 +250,11 @@ wheels = [
 
 [[package]]
 name = "structlog"
-version = "24.4.0"
+version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/a3/e811a94ac3853826805253c906faa99219b79951c7d58605e89c79e65768/structlog-24.4.0.tar.gz", hash = "sha256:b27bfecede327a6d2da5fbc96bd859f114ecc398a6389d664f62085ee7ae6fc4", size = 1348634 }
+sdist = { url = "https://files.pythonhosted.org/packages/25/fe/578db23e17392a8693b45a7b7dc6985370f51dd937157def8ecc7b20930d/structlog-25.1.0.tar.gz", hash = "sha256:2ef2a572e0e27f09664965d31a576afe64e46ac6084ef5cec3c2b8cd6e4e3ad3", size = 1364973 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/65/813fc133609ebcb1299be6a42e5aea99d6344afb35ccb43f67e7daaa3b92/structlog-24.4.0-py3-none-any.whl", hash = "sha256:597f61e80a91cc0749a9fd2a098ed76715a1c8a01f73e336b746504d1aad7610", size = 67180 },
+    { url = "https://files.pythonhosted.org/packages/c1/14/e9aed6c820fa166e8a19a19e663e98bd5538004d68a70c5752458ca3656e/structlog-25.1.0-py3-none-any.whl", hash = "sha256:843fe4f254540329f380812cbe612e1af5ec5b8172205ae634679cd35a6d6321", size = 68921 },
 ]
 
 [[package]]
@@ -277,22 +277,22 @@ wheels = [
 
 [[package]]
 name = "zizmor"
-version = "1.3.1"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/bb/9a9411727ac3c92450dca637d7d304512e127ebf2314919e8d2cbffaaee0/zizmor-1.3.1.tar.gz", hash = "sha256:e3742f9000c9d9474312bc7f2e62249d7970cf45df7a9bb51c6991f0e69ada08", size = 278849 }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/39/c5b5dfda888515bbe930c27f45a7583c85a91ff6e6aa154d7f93b403115d/zizmor-1.4.1.tar.gz", hash = "sha256:6f08181ec2ea8f3d9625e3fa9441b06f3d2c123e6885cc3a32a5c0843726da48", size = 283321 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/22/fd82b964566969b4a1182f04a22d02bdde27f99836f1cbe5cde4fac9c668/zizmor-1.3.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:21f5df91fc4713d6055479e7b4b98973ba42950d86fa11bd82876f5910ee5834", size = 4529072 },
-    { url = "https://files.pythonhosted.org/packages/dc/11/61081631790cfa2919c2780e1ba1c2bac0a3522324c178e49ff24b8c0ecd/zizmor-1.3.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eca8730421777056f8bfc052c188abef95d91b7eff92154f8277f4f7a0dc1e43", size = 4298208 },
-    { url = "https://files.pythonhosted.org/packages/19/3a/71b2efa0c35cf70d55a9e2484b34e32d5bc17eb0416e5c8eb05e708675ee/zizmor-1.3.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:adcd62f0e5c438211889cecd07cf7a6ef5801016155ef449adbaa929551cd6f5", size = 4463700 },
-    { url = "https://files.pythonhosted.org/packages/44/67/fe9babcbc2ec71404e306c30f2732bc08e0477e58052ca8a166c9bf06e13/zizmor-1.3.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:14c335bd4900ee278f8dfe0de012a04eefb3ae1a19976ed561dd03636e0bd989", size = 4553822 },
-    { url = "https://files.pythonhosted.org/packages/84/81/e361287a247f51e390c99f9673aa44266dc8ec7d45b0003637e76d8c0f99/zizmor-1.3.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3873dae75f2bfa5dfe22f123b480bb61d16b8392922350c9d363b81c36445217", size = 4846254 },
-    { url = "https://files.pythonhosted.org/packages/a9/03/4857b96b5576510f28d0ccde92e16878f097f9db1d5537726841184c5c05/zizmor-1.3.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0a98ddc5a3aa2722db168dc1cbcdee4ada6b7afcf11a2a2c84775d15a82918dc", size = 5996790 },
-    { url = "https://files.pythonhosted.org/packages/c0/25/4be1fa0c99d5ce4751afba87d3ccea0385d9a307d0f05bd6aafb2b7b44a5/zizmor-1.3.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a2f92d74c48c47fcf7aa0679bdc23fed437f61cc28553ab3f48f6d3392d9b8b", size = 4677633 },
-    { url = "https://files.pythonhosted.org/packages/b9/a1/05dad04ea6109fbfa76e97e6e4978e9f59efb14210ef3fb331e4781f91cd/zizmor-1.3.1-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:96fc7fa4ec82be0f8248258a6f1b5ddbd69f69b567bb5654d801d8b2a08b304c", size = 4450060 },
-    { url = "https://files.pythonhosted.org/packages/10/66/649efae076dc14388a5bfebcf2aa17281a1abf7a8c55abb7c72a0ccf4cc7/zizmor-1.3.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:447c3637f2533680e4b63a93687aa9618257c429021c447f23c2884dbc10387b", size = 4402422 },
-    { url = "https://files.pythonhosted.org/packages/3c/38/9139895ce3be71a16724db986d322cdcce64a083711e5ad54137a29df44f/zizmor-1.3.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:54d8a7bf479d26cd217ce9105aa5961537d398690a40e4df1111c50abf3420f3", size = 4387018 },
-    { url = "https://files.pythonhosted.org/packages/c8/b6/52e648536523703cb521a0e842b3ba638c9e228f831890159dcdd372f3ae/zizmor-1.3.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:29d0a0fa44803566688f0b0ce0d5e2bd28cde23b3ce67d0ff3efed672adfb189", size = 4481117 },
-    { url = "https://files.pythonhosted.org/packages/4b/b3/b7d05ed56c2ea546b233fee46192ae40105597eaa9c5fd9e1aa79ff29e1d/zizmor-1.3.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:735c2a318f8aac7af5db25eac4face2bef603d7359d1fbe832b3b527c2dac159", size = 4730994 },
-    { url = "https://files.pythonhosted.org/packages/3d/ef/13b7da3e47e6a3141f0e3bf334fc67239b4f4892b5af280d17f99f139c04/zizmor-1.3.1-py3-none-win32.whl", hash = "sha256:de975889b15c2f6599f1a3da863a21ada7088d61174aed008d29678008b9d8f9", size = 3802946 },
-    { url = "https://files.pythonhosted.org/packages/24/5d/6bc3401570b05e149d36dfd31eae2e638b12d44a8cb6e5e87f9258bcbbd3/zizmor-1.3.1-py3-none-win_amd64.whl", hash = "sha256:227bcb159f49fffb113e59eda0d712660e48ec40dbf9d4367453441b452d5fda", size = 4280695 },
+    { url = "https://files.pythonhosted.org/packages/9a/be/691b4464cc380a0906d7981e02818a152988a5bf21bd71c1cc2fdc9c0bf8/zizmor-1.4.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fdbcd3a7173a8adc8dc22b834627fb5229568fca15f8b697cc034dd8fa72caae", size = 4547420 },
+    { url = "https://files.pythonhosted.org/packages/16/4d/57db4bf73f38c420452f67a9b8a20be0f7b70fa7ea6c66ad94649fed621e/zizmor-1.4.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d43e3c6b478cb28bafad99cc85c60f4584d8e0196e8bc43e7410182c5c1e9a01", size = 4306106 },
+    { url = "https://files.pythonhosted.org/packages/8f/8e/faeb02dd218dcee24b4e544ac29db30b96652080c112b85d2dd84f0a742e/zizmor-1.4.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9f8b2f4bf85560a40cf1803b61c46720609c290b8e9776324ad1f9b35c7637a6", size = 4426722 },
+    { url = "https://files.pythonhosted.org/packages/02/34/92e51d55c47320e668f14e8b793fd4653d66f647741d2a103ce1cfaafcc9/zizmor-1.4.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:974a132ee707c4746109df1d8ea7c1442a51f673702a5bf552d026233fe5a520", size = 4524054 },
+    { url = "https://files.pythonhosted.org/packages/e3/a7/f7aa6b7d15cd4e8ec8b47f97a49b8623edcadd92c96d9f92185c181db879/zizmor-1.4.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:34ed8b103c151845a6f660ae63d15ccaa7b38fa2e63d8cbfcc7d9b1961258385", size = 4828959 },
+    { url = "https://files.pythonhosted.org/packages/e3/0b/931127dfbfade350605874ce944289c7a0b2b08c466e6f0f3d1c6310be83/zizmor-1.4.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:194b95ccfd75eb152548d887cbbe60650fae9fcbd91d4724524632fe9fee2e02", size = 5873275 },
+    { url = "https://files.pythonhosted.org/packages/c5/a2/a0aae38df2dbb73a6eada6c3254ecec95214e8e914c8213c1e4ff1f37172/zizmor-1.4.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a7c983a2e21fe13fda6dec77a52cb611e2951e7b16872b0bbf7bd173ad8b45e", size = 4663743 },
+    { url = "https://files.pythonhosted.org/packages/8f/8d/4c4f2640ba129958dbf98565ea84540b361c90842b5fb00e2bd774fa5f29/zizmor-1.4.1-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:15b77e55a395f265f6be584e1eaea651f69e686961d13f9e4cb8a20bde92f7a0", size = 4435000 },
+    { url = "https://files.pythonhosted.org/packages/b4/20/7e25b6d5e3afd26d65bcbdefaa75a7a590c249a9ad99789107751b597b7a/zizmor-1.4.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3a895f56df7c238df0e67e76a0c3b94f04f87eb3fbd497497e12c6df1a28e183", size = 4422897 },
+    { url = "https://files.pythonhosted.org/packages/a3/dc/d5cd912b5ecf65fa5016c07a3f1c2541ed8899c66a70367bf3a9d63f19db/zizmor-1.4.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f814f2e67aad5b22f130e432e499fe1a8fc83809fc7ed1e0e6e4ff16cd0c83ad", size = 4393432 },
+    { url = "https://files.pythonhosted.org/packages/da/62/4558f2667b58941b9d9f2c7b7bf18aa6f4102700cf30d17e1fe9bcc7c1dc/zizmor-1.4.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9a82a126597698dbf81afa540760d9bb68e65be9ec4670276923df2adce98dc7", size = 4459199 },
+    { url = "https://files.pythonhosted.org/packages/95/4a/42c529ab3f1ddbdd5afb0ea691a7f6f4bab494a4d09d0063db181f47095c/zizmor-1.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1b4901ffeae6c8cfafe88f5f0dc54cf81dad8f9b20a1c72be2884e3f70080bb8", size = 4747714 },
+    { url = "https://files.pythonhosted.org/packages/d5/74/0d1d3fd87127db1a89c7af565f51d29b3124df84e930edbdf818e0094742/zizmor-1.4.1-py3-none-win32.whl", hash = "sha256:f41fd36b42757d8f55f3c1d92068fd10c6f8375b08fd646a9c2adff443c5c7e1", size = 3809746 },
+    { url = "https://files.pythonhosted.org/packages/cf/6e/fbe241dd5e97ff2df6e675790b4fdb4fc62b8a07e2232be14e6eb2d8b601/zizmor-1.4.1-py3-none-win_amd64.whl", hash = "sha256:4547a1fe8b0b608d029b6e30603dc036446fc72f5facb0a4c5c48066d5fba78b", size = 4293836 },
 ]


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes aimed at improving code quality checks, updating dependencies, and enhancing pre-commit hooks. The most important changes include updating the `ruff` commands, modifying the `Dockerfile` and `pyproject.toml` dependencies, and revamping the pre-commit hooks to include new checks.

### Code Quality Checks:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L59-R59): Updated the `ruff` commands from `just ruff-lint` to `just ruff-lint-check` to ensure more comprehensive lint checks. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L59-R59) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L74-R74)

### Dependency Updates:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L8-R8): Updated the `uv` package from version 0.6.2 to 0.6.3.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R23): Updated dependencies including `structlog` to 25.1.0, `ruff` to 0.9.9, `zizmor` to 1.4.1, and `uv` to 0.6.3.

### Pre-commit Hooks:
* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cR78-R92): Added new `ruff-checks` command to check for all `ruff` issues and renamed existing `ruff` commands for clarity.
* [`githooks/pre-commit`](diffhunk://#diff-d5fe9d324948511c959e14d0aa311bb057ce7236626bb86fa51351dc26845a4dL4-R38): Overhauled the pre-commit hook script to run multiple checks including `gitleaks`, `prettier`, and `ruff`.
* Removed individual pre-commit scripts (`gitleaks.sh`, `justfile.sh`, `prettier.sh`, `python.sh`) as they are now integrated into the main pre-commit script. [[1]](diffhunk://#diff-b488692093f21df73d5c8d67f3a6df3273b7199a34ca84e9c9e1a115b20df271L1-L4) [[2]](diffhunk://#diff-fcd01eccc95d37bac6ab073a69ec60e574b754774360a13f31e1a39466668fc9L1-L4) [[3]](diffhunk://#diff-1e2ab1eef74462625d345d9811c6cd8e51996878583f4a9878ad8d62ec7d014dL1-L4) [[4]](diffhunk://#diff-f13793c94aec64ea3a3f3f3bcc4f045eeb9d66b5d895396175dd6f49ae3302b1L1-L8)