### PR TITLE
chore: Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,8 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-      - "/.github/actions/setup-dependencies"
-      - "/.github/actions/local"
+      - ".github/actions/setup-dependencies"
+      - ".github/actions/local"
     commit-message:
       prefix: "deps(github-actions)"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,22 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-      - ".github/actions/setup-dependencies"
-      - ".github/actions/local"
+      - "/.github/actions/setup-dependencies"
+      - "/.github/actions/local"
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"
@@ -27,9 +31,11 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       docker:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:
@@ -43,9 +49,11 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       python:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration to improve the scheduling and grouping of dependency updates. The most notable changes include adding a timezone specification, refining group applicability, and excluding specific patterns for `github-actions`.

### Scheduling improvements:
* Added a `timezone` field to the schedule configuration, specifying "Europe/London" to ensure updates are triggered at the correct local time. (`.github/dependabot.yml`, [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R14-R22) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R34-R38) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R52-R56)

### Group configuration enhancements:
* Introduced the `applies-to` field for the `github-actions`, `docker`, and `python` groups to specify that these groups apply to "version-updates". (`.github/dependabot.yml`, [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R14-R22) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R34-R38) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R52-R56)
* Added `exclude-patterns` to the `github-actions` group to exclude updates matching the "super-linter/*" pattern. (`.github/dependabot.yml`, [.github/dependabot.ymlR14-R22](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R14-R22))