### PR TITLE
chore: Fix Zizmor SARIF Command

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -179,14 +179,16 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Setup Dependencies
-        uses: ./.github/actions/setup-dependencies
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      - name: Set up Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Run zizmor 🌈
-        run: uv run zizmor --format sarif . > results.sarif
+        run: just zizmor-check-sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.15
+        uses: github/codeql-action/upload-sarif@v3.28.17
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/Justfile
+++ b/Justfile
@@ -150,7 +150,11 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    zizmor . --pedantic --persona=pedantic
+    uvx zizmor . --persona=pedantic
+
+# Run zizmor checking with sarif output
+zizmor-check-sarif:
+    uvx zizmor . --persona=pedantic --format sarif > results.sarif
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the CI workflow and the `Justfile` to improve dependency management and streamline the execution of the `zizmor` tool. Key changes include replacing the `setup-dependencies` action with specific setup actions for `uv` and `Just`, updating the `zizmor` command to use `uvx`, and modifying the SARIF upload action to a newer version.

### CI Workflow Updates:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L182-R191): Replaced the `setup-dependencies` action with `astral-sh/setup-uv` (v6.0.1) and `extractions/setup-just` (v3) to explicitly install and set up `uv` and `Just`. Updated the `zizmor` execution command to use `just zizmor-check-sarif` for consistency. Upgraded the SARIF upload action to `github/codeql-action/upload-sarif@v3.28.17` for improved compatibility.

### `Justfile` Updates:
* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL153-R157): Replaced the `zizmor-check` command to use `uvx` for execution. Added a new `zizmor-check-sarif` command to generate SARIF output, aligning with the updated CI workflow.