### PR TITLE
deps(github-actions): Bump SuperLinter to 7.4.0

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Lint Code Base
-        uses: super-linter/super-linter@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
+        uses: super-linter/super-linter@12150456a73e248bdc94d0794898f94e23127c88 # v7.4.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the version of the Super-Linter GitHub Action used in the code-check workflow.

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L28-R28): Updated the Super-Linter action from version `v7.3.0` to `v7.4.0` by changing its commit hash reference.
