### PR TITLE
ci: Change Jobs to Common Pull Request Tasks

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, synchronize]
 
 permissions:
-  contents: read
+  pull-requests: read
 
 jobs:
   check-pull-request-title:
@@ -16,48 +16,6 @@ jobs:
         uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2
         with:
           allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: ,build(deps): " # title should start with the given prefix
-  labeller:
-    name: Label Pull Request
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Label Pull Request
-        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          configuration-path: .github/other-configurations/labeller.yml
-          sync-labels: true
-      - name: Add Size Labels
-        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          sizes: >
-            {
-              "0": "XS",
-              "40": "S",
-              "100": "M",
-              "200": "L",
-              "800": "XL",
-              "2000": "XXL"
-            }
-
-  dependency-review:
-    name: Dependency Review
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Dependency Review
-        uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8 # v4.6.0
-        with:
-          comment-summary-in-pr: on-failure
 
   docker-build-and-run:
     name: Build Docker Image and Run
@@ -76,3 +34,11 @@ jobs:
         run: just docker-build
       - name: Run Docker Image
         run: just docker-run
+
+  common-pull-request-tasks:
+    name: Common Pull Request Tasks
+    permissions:
+      pull-requests: write
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@14445779094fde883fdb9f65946fcae6c25f46c0 # v2025.05.14.01
+    secrets:
+      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description


This pull request updates the GitHub Actions workflow configuration in `.github/workflows/pull-request-tasks.yml`. The changes include modifying permissions, removing redundant jobs, and introducing a reusable workflow for common pull request tasks.

### Workflow Permissions Updates:
* Updated permissions from `contents: read` to `pull-requests: read` for better alignment with the workflow's scope.

### Job Simplifications:
* Removed the `labeller` job, which handled pull request labeling and size categorization, as it is no longer needed.
* Removed the `dependency-review` job, which performed dependency analysis and added comments to pull requests, simplifying the workflow.

### Reusable Workflow Integration:
* Added a new `common-pull-request-tasks` job that uses a reusable workflow (`JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml`) to handle common tasks, streamlining the configuration.
