### PR TITLE
ci: Migrate to Reusable CodeQL Workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -105,28 +105,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-  run-codeql-analysis:
+  codeql-checks:
     name: CodeQL Analysis
-    runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      contents: read
       security-events: write
     strategy:
       matrix:
-        language: [python, actions]
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
-        with:
-          languages: ${{ matrix.language }}
-          queries: security-and-quality
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
+        language: [actions, python]
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@75ceb782a5815a98162de1321c852df74830a493 # v2025.05.24.01
+    with:
+      language: ${{ matrix.language }}
 
   run-code-limit:
     name: Run CodeLimit


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the CodeQL analysis workflow in `.github/workflows/code-checks.yml` to improve maintainability and streamline the configuration by switching to a reusable workflow.

### Workflow improvements:
* Renamed the `run-codeql-analysis` job to `codeql-checks` for consistency.
* Updated the job to use a reusable workflow from `JackPlowman/reusable-workflows` instead of defining all steps inline, reducing duplication and simplifying maintenance.
* Adjusted permissions for the job, changing `statuses: write` to `contents: read` for improved security.
* Refactored the `matrix.language` configuration to ensure consistency in the language list.