### PR TITLE
chore: Fix Zizmor Warnings

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -9,6 +9,9 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push-package:
     name: Build and Push Package


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub Actions workflow for releasing packages by adding permissions to the `env` section.

* [`.github/workflows/release-package.yml`](diffhunk://#diff-3099c6260c6951cb01f86e1ae6d3445e822dfd243571b51a1737ec2cee3a7e56R12-R14): Added `permissions` with `contents: read` to define the required permissions for the workflow.