### PR TITLE
ci: Remove SuperLinter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,6 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "super-linter/super-linter"
           - "JackPlowman/reusable-workflows"
         update-types:
           - "patch"

--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -12,11 +12,7 @@ dependencies:
 configurations:
   - any:
       - changed-files:
-          - any-glob-to-any-file:
-              [
-                ".github/other-configurations/*",
-                ".github/super-linter-configurations/*",
-              ]
+          - any-glob-to-any-file: [".github/other-configurations/*"]
 # Language
 markdown:
   - any:

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -16,35 +16,6 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  check-code-quality:
-    name: Check Code Quality
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Lint Code Base
-        uses: super-linter/super-linter@12150456a73e248bdc94d0794898f94e23127c88 # v7.4.0
-        env:
-          VALIDATE_ALL_CODEBASE: true
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LINTER_RULES_PATH: .github/super-linter-configurations
-          YAML_ERROR_ON_WARNING: true
-          VALIDATE_EDITORCONFIG: false
-          VALIDATE_GIT_COMMITLINT: false
-          VALIDATE_NATURAL_LANGUAGE: false
-          VALIDATE_PYTHON_BLACK: false
-          VALIDATE_PYTHON_FLAKE8: false
-          VALIDATE_PYTHON_ISORT: false
-          VALIDATE_PYTHON_MYPY: false
-          VALIDATE_PYTHON_PYLINT: false
-          VALIDATE_PYTHON_RUFF: false
-
   check-python-code-format-and-quality:
     name: Check Python Code Format and Quality
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the use of Super-Linter from the repository's CI and configuration files. The main changes are focused on cleaning up workflows and configuration that referenced Super-Linter, streamlining code quality checks to rely on other tools.

**Removal of Super-Linter integration:**

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L19-L47): Deleted the entire `check-code-quality` job, which previously used Super-Linter for code linting.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L22): Removed the exclusion pattern for `super-linter/super-linter` from the Dependabot configuration.
* [`.github/other-configurations/labeller.yml`](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9L15-R15): Updated the labeller configuration to remove references to Super-Linter configuration files.