### PR TITLE
ci: Update Pull Request Tasks Permissions

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   check-pull-request-title:
     name: Check Pull Request Title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Check Pull Request Title
         uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor adjustment to the GitHub Actions workflow configuration to move the `pull-requests: read` permission from the global workflow level to the specific job that requires it.

- Workflow permissions update:
  * In `.github/workflows/pull-request-tasks.yml`, the global `permissions` block was changed to an empty object, and the `pull-requests: read` permission was moved into the `check-pull-request-title` job, restricting its scope to only that job.