### PR TITLE
chore: Update trivy config

### DIFF
--- a/.github/tool-configurations/trivy.yml
+++ b/.github/tool-configurations/trivy.yml
@@ -9,7 +9,6 @@ scan:
   scanners:
     - vuln
     - secret
-    - misconfig
     - license
 vulnerability:
   type:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small configuration change to the Trivy scanner settings. The `misconfig` scanner has been removed from the list of enabled scanners in `.github/tool-configurations/trivy.yml`.